### PR TITLE
Fix code scanning alert no. 16: Clear-text logging of sensitive information

### DIFF
--- a/code/frameworks/angular/src/client/docs/__testfixtures__/doc-button/input.ts
+++ b/code/frameworks/angular/src/client/docs/__testfixtures__/doc-button/input.ts
@@ -185,7 +185,7 @@ export class InputComponent<T> {
    * @param password Some `password`.
    */
   private privateMethod(password: string) {
-    console.log(password);
+    console.log('Password received');
   }
 
   @Input('showKeyAlias')


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/16](https://github.com/akabarki/silver-meme/security/code-scanning/16)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead of logging the actual password, we can log a placeholder or a masked version of the password. This way, we maintain the ability to debug without exposing sensitive information.

- Replace the `console.log(password)` statement with a log that does not reveal the actual password.
- We can log a generic message indicating that a password was received without logging the actual value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
