### PR TITLE
Fix code scanning alert no. 15: Incomplete string escaping or encoding

### DIFF
--- a/code/core/src/manager-api/modules/refs.ts
+++ b/code/core/src/manager-api/modules/refs.ts
@@ -95,7 +95,7 @@ export const getSourceType = (source: string, refId?: string) => {
 };
 
 export const defaultStoryMapper: API_StoryMapper = (b: any, a: any) => {
-  return { ...a, kind: a.kind.replace('|', '/') };
+  return { ...a, kind: a.kind.replace(/\|/g, '/') };
 };
 
 const addRefIds = (input: API_IndexHash, ref: API_ComposedRef): API_IndexHash => {


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/15](https://github.com/akabarki/silver-meme/security/code-scanning/15)

To fix the problem, we need to ensure that all occurrences of the `|` character in the `a.kind` string are replaced with `/`. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every instance of `|` in the string is replaced, not just the first one.

- Modify the `replace` method call on line 98 to use a regular expression with the global flag.
- No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
