### PR TITLE
Fix code scanning alert no. 13: Bad HTML filtering regexp

### DIFF
--- a/code/lib/cli-storybook/package.json
+++ b/code/lib/cli-storybook/package.json
@@ -60,7 +60,8 @@
     "semver": "^7.3.7",
     "storybook": "workspace:*",
     "tiny-invariant": "^1.3.1",
-    "ts-dedent": "^2.0.0"
+    "ts-dedent": "^2.0.0",
+    "htmlparser2": "^9.1.0"
   },
   "devDependencies": {
     "@types/cross-spawn": "^6.0.2",


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/13](https://github.com/akabarki/silver-meme/security/code-scanning/13)

To fix the problem, we should replace the custom regular expression with a well-tested library that can handle HTML comments correctly, including those that span multiple lines. The `htmlparser2` library is a robust solution for parsing HTML and can be used to safely process comments.

1. Install the `htmlparser2` library.
2. Replace the custom regex-based comment replacement logic with a parser-based approach using `htmlparser2`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
