### PR TITLE
Fix code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/code/renderers/html/package.json
+++ b/code/renderers/html/package.json
@@ -51,7 +51,8 @@
     "@storybook/manager-api": "workspace:^",
     "@storybook/preview-api": "workspace:^",
     "@storybook/theming": "workspace:^",
-    "ts-dedent": "^2.0.0"
+    "ts-dedent": "^2.0.0",
+    "dompurify": "^3.1.7"
   },
   "devDependencies": {
     "typescript": "^5.3.2"

--- a/code/renderers/html/template/components/Form.js
+++ b/code/renderers/html/template/components/Form.js
@@ -1,3 +1,5 @@
+import DOMPurify from 'dompurify';
+
 export const Form = ({ onSuccess }) => {
   const container = document.createElement('div');
 
@@ -19,14 +21,15 @@ export const Form = ({ onSuccess }) => {
     e.preventDefault();
 
     const { value } = form.querySelector('input'); // Store the current value
+    const sanitizedValue = DOMPurify.sanitize(value); // Sanitize the value
 
     setTimeout(() => {
-      container.innerHTML = getInnerHTML({ complete: true, value });
+      container.innerHTML = getInnerHTML({ complete: true, value: sanitizedValue });
     }, 500);
     setTimeout(() => {
-      container.innerHTML = getInnerHTML({ complete: false, value });
+      container.innerHTML = getInnerHTML({ complete: false, value: sanitizedValue });
     }, 1500);
-    onSuccess(value);
+    onSuccess(sanitizedValue);
   });
 
   return container;


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/11](https://github.com/akabarki/silver-meme/security/code-scanning/11)

To fix this issue, we need to ensure that any user input is properly escaped before being inserted into the DOM. This can be achieved by using a library like `DOMPurify` to sanitize the input. `DOMPurify` is a well-known library that helps to sanitize HTML and prevent XSS attacks.

1. Install `DOMPurify` if it is not already installed.
2. Import `DOMPurify` in the file.
3. Use `DOMPurify` to sanitize the `value` before inserting it into the HTML string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
