### PR TITLE
Fix code scanning alert no. 10: Missing rate limiting

### DIFF
--- a/code/core/package.json
+++ b/code/core/package.json
@@ -289,7 +289,8 @@
     "recast": "^0.23.5",
     "semver": "^7.6.2",
     "util": "^0.12.5",
-    "ws": "^8.2.3"
+    "ws": "^8.2.3",
+    "express-rate-limit": "^7.4.0"
   },
   "devDependencies": {
     "@aw-web-design/x-default-browser": "1.4.126",

--- a/code/core/src/core-server/utils/server-statics.ts
+++ b/code/core/src/core-server/utils/server-statics.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { basename, isAbsolute, posix, resolve, sep, win32 } from 'node:path';
+import rateLimit from 'express-rate-limit';
 
 import { getDirectoryFromWorkingDir } from '@storybook/core/common';
 import type { Options } from '@storybook/core/types';
@@ -50,7 +51,12 @@ export async function useStatics(router: Router, options: Options) {
     );
   }
 
-  router.get(`/${basename(faviconPath)}`, (req, res) => res.sendFile(faviconPath));
+  const faviconLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  router.get(`/${basename(faviconPath)}`, faviconLimiter, (req, res) => res.sendFile(faviconPath));
 }
 
 export const parseStaticDir = async (arg: string) => {


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/10](https://github.com/akabarki/silver-meme/security/code-scanning/10)

To fix the problem, we will introduce rate limiting to the route handler that serves the favicon. We will use the `express-rate-limit` package to limit the number of requests to this endpoint. Specifically, we will:
1. Install the `express-rate-limit` package.
2. Import the package in the file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the favicon route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
