### PR TITLE
Fix code scanning alert no. 18: Server-side URL redirect

### DIFF
--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -51,7 +51,12 @@ const startVerdaccio = async () => {
       const proxy = http.createServer((req, res) => {
         // if request contains "storybook" redirect to verdaccio
         if (req.url?.includes('storybook') || req.url?.includes('/sb') || req.method === 'PUT') {
-          res.writeHead(302, { Location: 'http://localhost:6002' + req.url });
+          const targetUrl = 'http://localhost:6002' + req.url;
+          if (isLocalUrl(targetUrl)) {
+            res.writeHead(302, { Location: targetUrl });
+          } else {
+            res.writeHead(302, { Location: 'http://localhost:6002' });
+          }
           res.end();
         } else {
           // forward to npm registry
@@ -94,6 +99,14 @@ const startVerdaccio = async () => {
       }, 10000);
     }),
   ]) as Promise<Server>;
+};
+
+const isLocalUrl = (path: string) => {
+  try {
+    return new URL(path, 'http://localhost:6002').origin === 'http://localhost:6002';
+  } catch (e) {
+    return false;
+  }
 };
 
 const currentVersion = async () => {


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/18](https://github.com/akabarki/silver-meme/security/code-scanning/18)

To fix the problem, we need to validate the user input before using it in the URL redirection. One way to do this is to ensure that the URL path is local and does not contain any malicious redirection. We can use the `URL` constructor to parse the URL and check that it remains within the expected domain.

1. Create a function `isLocalUrl` to validate that the URL path is local.
2. Use this function to check the `req.url` before performing the redirection.
3. If the URL is not valid, redirect to a safe default location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
