### PR TITLE
Fix code scanning alert no. 8: Information exposure through a stack trace

### DIFF
--- a/code/core/src/core-server/utils/stories-json.ts
+++ b/code/core/src/core-server/utils/stories-json.ts
@@ -65,8 +65,9 @@ export function useStoriesJson({
       res.header('Content-Type', 'application/json');
       res.send(JSON.stringify(index));
     } catch (err) {
+      console.error('Error occurred while processing /index.json request:', err);
       res.status(500);
-      res.send(err instanceof Error ? err.toString() : String(err));
+      res.send('An internal server error occurred');
     }
   });
 }


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/8](https://github.com/akabarki/silver-meme/security/code-scanning/8)

To fix the problem, we should avoid sending detailed error information to the client. Instead, we can log the error on the server and send a generic error message to the client. This approach ensures that sensitive information is not exposed while still allowing developers to debug issues using server logs.

- Modify the catch block to log the error on the server.
- Send a generic error message to the client instead of the error's string representation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
