### PR TITLE
Fix code scanning alert no. 5: Inefficient regular expression

### DIFF
--- a/code/addons/docs/src/compiler/index.test.ts
+++ b/code/addons/docs/src/compiler/index.test.ts
@@ -15,7 +15,7 @@ const clean = (code: string) => {
     /export default function MDXContent\([^)]*\) \{(?:[^{}]*|{(?:[^{}]*|{[^{}]*})*})*\}/gs;
 
   const mdxMissingReferenceRegex =
-    /function _missingMdxReference\([^)]*\) \{(?:[^{}]*|{(?:[^{}]*|{[^{}]*})*})*\}/gs;
+    /function _missingMdxReference\([^)]*\) \{(?:[^{}]*?|{(?:[^{}]*?|{[^{}]*?})*?})*?\}/gs;
 
   return code.replace(mdxMissingReferenceRegex, '').replace(mdxContentRegex, '');
 };


### PR DESCRIPTION
Fixes [https://github.com/akabarki/silver-meme/security/code-scanning/5](https://github.com/akabarki/silver-meme/security/code-scanning/5)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. Specifically, we can replace the `[^{}]*` pattern with a more precise pattern that avoids nested quantifiers. One way to achieve this is by using a non-greedy match for the content inside the braces.

- **General Fix:** Modify the regular expression to use non-greedy matching for the content inside the braces.
- **Detailed Fix:** Change the pattern `[^{}]*` to `[^{}]*?` to make the match non-greedy.
- **Files/Regions/Lines to Change:** Modify the regular expression on line 18 in the file `code/addons/docs/src/compiler/index.test.ts`.
- **Needed Changes:** No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
